### PR TITLE
fix(chu): 添加 Umiguri 新版本头部标签到静默忽略列表

### DIFF
--- a/parser/chu/UgcParser.cs
+++ b/parser/chu/UgcParser.cs
@@ -34,7 +34,7 @@ public class UgcParser: BaseChuParser
 
             if (inHeader)
             {
-                if (line == "@ENDHEAD")
+                if (line.StartsWith("@ENDHEAD"))
                 {
                     inHeader = false;
                     continue;
@@ -183,8 +183,8 @@ public class UgcParser: BaseChuParser
             case "@EXVER": case "@SORT": case "@BGM": case "@BGMOFS": case "@BGMPRV":
             case "@JACKET": case "@BGIMG": case "@BGMODE": case "@FLDCOL": case "@FLDIMG":
             case "@FLAG": case "@ATINFO": case "@DLURL": case "@COPYRIGHT": case "@LICENSE":
-            case "@MAINTIL": case "@TIL":
-            case "@MAINBPM": case "@USETIL": case "@ENDHEAD":
+            case "@MAINTIL": case "@TIL": case "@USETIL":
+            case "@MAINBPM":
             case "@BGSCENE": case "@FLDSCENE": case "@RLDATE": case "@CMT":
                 break;
 

--- a/parser/chu/UgcParser.cs
+++ b/parser/chu/UgcParser.cs
@@ -184,6 +184,8 @@ public class UgcParser: BaseChuParser
             case "@JACKET": case "@BGIMG": case "@BGMODE": case "@FLDCOL": case "@FLDIMG":
             case "@FLAG": case "@ATINFO": case "@DLURL": case "@COPYRIGHT": case "@LICENSE":
             case "@MAINTIL": case "@TIL":
+            case "@MAINBPM": case "@USETIL": case "@ENDHEAD":
+            case "@BGSCENE": case "@FLDSCENE": case "@RLDATE": case "@CMT":
                 break;
 
             case "@SPDMOD":


### PR DESCRIPTION
添加以下 Umiguri 新版本使用的头部标签到 UgcParser 的静默忽略列表：

- \@MAINBPM\ — 主 BPM 显示值
- \@USETIL\ — TIL 切换指令
- \@ENDHEAD\ — 头部结束标记
- \@BGSCENE\ — 背景场景
- \@FLDSCENE\ — 地面场景
- \@RLDATE\ — 发布日期
- \@CMT\ — 注释

这些标签是 Umiguri 的元数据/渲染相关标签，对转谱逻辑不影响，之前会触发「未知头部标签」的 Info 级别警告。

## Summary by Sourcery

错误修复：
- 防止 Umiguri 元数据和与渲染相关的头部标签在 UgcParser 中产生多余的信息级 “unknown header” 警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent new Umiguri metadata and rendering-related header tags from generating spurious info-level "unknown header" warnings in UgcParser.

</details>